### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = true
+max_line_length = 120


### PR DESCRIPTION
This file uses https://editorconfig.org, which is a cross-editor
configuration file that specifies basic editor settings, such as
indentation size and method.