### PR TITLE
Add asset_precompile as an allowed Rails env

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Rails/SkipsModelValidations:
   Enabled: false
 
 Rails/UnknownEnv:
-  Environments: [ production, staging, development, test ]
+  Environments: [ production, staging, development, test, asset_precompile ]
 
 Style/EmptyMethod:
   EnforcedStyle: expanded


### PR DESCRIPTION
The `asset_precompile` environment is intended to be used during build
in order to enable asset compilation in isolated environments and speed
up the build process