### PR TITLE
update IndentArray config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,7 +89,7 @@ Layout/DotPosition:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Style/TrailingCommaInArrayLiteral:


### PR DESCRIPTION
RuboCop 0.70 (see 4ormat/4ormat#8220) renamed `Layout/IndentArray` to `IndentFirstArrayElement`