### PR TITLE
add rubocop-performance again

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require: 
+  - rubocop-rspec
+  - rubocop-performance
 
 inherit_mode:
   merge:


### PR DESCRIPTION
Reverts 4ormat/styleguide#8

`rubocop-performance` is available to Code Climate's RuboCop now.

https://github.com/codeclimate/codeclimate-rubocop/issues/187