### PR TITLE
RuboCop: align arguments with fixed indentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Performance/RedundantMerge:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Rails/ApplicationRecord:
   Enabled: false
 


### PR DESCRIPTION
## Layout/AlignArguments

### No

```ruby
update "thing",
       amount: 123,
       ok: true
```

### Yes

```ruby
update "thing",
  amount: 123,
  ok: true
```

This matches `Style/AlignParameters`, set in 4ormat/4ormat#2797

I checked against 4ormat and got

### Before

```
2621 files inspected, 522 offenses detected
```

### After

```
2621 files inspected, 194 offenses detected
```