### PR TITLE
Disable RSpec/MultipleExpectations rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,6 +131,9 @@ RSpec/ExampleLength:
 RSpec/FilePath:
   IgnoreMethods: true
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
This bites me a lot and I end up just manually overriding it with `:aggregate_failures`. There seem to me to be plenty of situations where multiple expectations are reasonable. An example:

```
  it "redirects HTTP to HTTPS if SSL enforcement is manually enabled", :aggregate_failures do
    allow(controller).to receive(:ssl_env_override).and_return "1"
    allow(controller).to receive(:env_should_force_ssl?).and_return false
    request.env["HTTPS"] = "off"
    get :index
    expect(response.status).to eq(301)
    expect(URI.parse(response.location)).to be_a(URI::HTTPS)
  end
```

I want to make  sure that the response  is a) a redirect, and b) redirects to an HTTPS URI. I could get fancy and try and match multiple things in one expectation, but that would make things much less readable. 

Looking for feedback on this change. Should this rule stay enabled?