### PR TITLE
update RuboCop config for 0.86

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,7 +88,7 @@ Layout/MultilineMethodCallIndentation:
 Style/MutableConstant:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Style/StringLiterals:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,3 +144,47 @@ RSpec/MultipleExpectations:
     it's necessary, you should add the :aggregate_failures option to the example
     so that the example doesn't immediately abort.
     More details at https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/aggregating-failures
+
+# RuboCop 0.8x new rules
+# https://docs.rubocop.org/rubocop/versioning.html
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true


### PR DESCRIPTION
Enable the new rules added in RuboCop after 0.77. It avoids a warning message when using newer versions of RuboCop. The gem bump for 4ormat is in 4ormat/4ormat#10953.

RuboCop now requires new rules to be [explicitly enabled or disabled](https://docs.rubocop.org/rubocop/versioning.html). The new rules all seemed reasonable, so I enabled them. When 0.90.0 is released we can remove the explicit config.