### PR TITLE
update RuboCop config for RuboCop 0.88

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -189,6 +189,9 @@ Style/HashAsLastArrayItem:
 Style/HashEachMethods:
   Enabled: true
 
+Style/HashLikeCase:
+  Enabled: true
+
 Style/HashTransformKeys:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -156,6 +156,9 @@ Layout/SpaceAroundMethodCallOperator:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
@@ -165,7 +168,22 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
+
 Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
   Enabled: true
 
 Style/HashEachMethods:
@@ -177,7 +195,13 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
+Style/RedundantAssignment:
+  Enabled: true
+
 Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
   Enabled: true
 
 Style/RedundantRegexpCharacterClass:


### PR DESCRIPTION
Enable the new rules added in RuboCop after 0.86. It avoids a warning message when using newer versions of RuboCop. See #18 for the last rules bump.

RuboCop now requires new rules to be [explicitly enabled or disabled](https://docs.rubocop.org/rubocop/versioning.html). The new rules all seemed reasonable, so I enabled them. When 0.90.0 is released we can remove the explicit config.

* [Lint/DuplicateElsifCondition](https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicateelsifcondition)
* [Style/AccessorGrouping](https://docs.rubocop.org/rubocop/cops_style.html#styleaccessorgrouping)
* [Style/ArrayCoercion](https://docs.rubocop.org/rubocop/cops_style.html#stylearraycoercion)
* [Style/BisectedAttrAccessor](https://docs.rubocop.org/rubocop/cops_style.html#stylebisectedattraccessor)
* [Style/CaseLikeIf](https://docs.rubocop.org/rubocop/cops_style.html#stylecaselikeif)
* [Style/HashAsLastArrayItem](https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem)
* [Style/HashLikeCase](https://docs.rubocop.org/rubocop/cops_style.html#stylehashlikecase)
* [Style/RedundantAssignment](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantassignment)
* [Style/RedundantFileExtensionInRequire](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantfileextensioninrequire)