### PR TITLE
add new rule for rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -389,3 +389,7 @@ Rails/WhereExists: # (new in 2.7)
 
 Rails/WhereNot: # (new in 2.8)
   Enabled: true
+
+# rubocop-rspec new rules
+RSpec/StubbedMock: # (new in 1.44)
+  Enabled: true


### PR DESCRIPTION
Enable new [`RSpec/StubbedMock`](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecstubbedmock) rule added in `rubocop-rspec` `1.44.1` (4ormat/4ormat#12355).