### PR TITLE
Update Layout/FirstHashElementIndentation to "consistent" in rubocop style guide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,9 @@ Layout/EndAlignment:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 


### PR DESCRIPTION
forcing 
```
Raven.extra_context({
  'heroku_app_name' => ENV['HEROKU_APP_NAME'],
})
```

to be

```
Raven.extra_context({
                      'heroku_app_name' => ENV['HEROKU_APP_NAME'],
                    })
```

IMO doesn't benefit us much.

[Rule reference](https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation)