### PR TITLE
split RSpec/SpecFilePath

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,8 +133,12 @@ RSpec/DescribedClass:
 RSpec/ExampleLength:
   Max: 10
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: true
   IgnoreMethods: true
+
+RSpec/SpecFilePathSuffix:
+  Enabled: true
 
 Style/FrozenStringLiteralComment:
   Enabled: false


### PR DESCRIPTION
`RSpec/SpecFilePath` was split into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix` in `rubocop-rspec` 2.24.0.

https://github.com/rubocop/rubocop-rspec/pull/1698

The old cop was enabled by default but the new ones are not 🤷

See https://github.com/4ormat/4ormat/pull/17161